### PR TITLE
Add support for log-filter regex

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -3,7 +3,7 @@ name: Build and deploy images
 on:
   schedule:
     # rebuild every Thursday at 9:24 UTC
-    - cron: '24 9 * * 3'
+    - cron: "24 9 * * 3"
   push:
     branches:
       - main
@@ -12,10 +12,7 @@ on:
       - bugfix/**
   pull_request:
     branches:
-      - '*'
-
-env:
-  TAG: "${{ github.run_id }}"
+      - "*"
 
 permissions:
   contents: read
@@ -25,7 +22,7 @@ permissions:
 jobs:
   build-images:
     name: Build Docker images
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       image: ghcr.io/seravo/flask
     steps:
@@ -76,28 +73,19 @@ jobs:
         with:
           image: "${{ env.image }}"
 
+      - id: refname
+        name: Convert git refname to valid Docker tag
+        run: echo "::set-output name=refname::$(echo "${{ github.ref_name }}" |sed 's/\//-/g')"
+
       - id: docker-tag
         name: Tag image with run id
         uses: Seravo/actions/docker-tag@v0.11
         with:
           source: "${{ env.image }}"
-          target: "${{ env.image }}:${{ env.TAG }}"
+          target: "${{ env.image }}:${{ steps.refname.outputs.refname }}"
 
       - id: docker-push
         name: Push image with run id
         uses: Seravo/actions/docker-push@v0.11
         with:
-          image: "${{ env.image }}:${{ env.TAG }}"
-
-      - id: docker-tag-commit
-        name: Tag image with commit id
-        uses: Seravo/actions/docker-tag@v0.11
-        with:
-          source: "${{ env.image }}"
-          target: "${{ env.image }}:${{ github.sha }}"
-
-      - id: docker-push-commit
-        name: Push image with commit id
-        uses: Seravo/actions/docker-push@v0.11
-        with:
-          image: "${{ env.image }}:${{ github.sha }}"
+          image: "${{ env.image }}:${{ steps.refname.outputs.refname }}"

--- a/.github/workflows/gnitpick.yml
+++ b/.github/workflows/gnitpick.yml
@@ -1,11 +1,11 @@
 ---
-name: 'Nitpick git commits'
+name: "Nitpick git commits"
 
 on: [push, pull_request]
 
 env:
   DOMAINS: seravo.com
-  PYTHON_VERSION: 3.6
+  PYTHON_VERSION: "3.10"
 
 jobs:
   nitpick:
@@ -14,8 +14,8 @@ jobs:
       - name: Setup repository
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.head_ref }}           
-      
+          ref: ${{ github.head_ref }}
+
       - name: Install Gnitpick
         run: curl -O https://raw.githubusercontent.com/Seravo/gnitpick/master/gnitpick.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG APT_PROXY
 
 ENV APPDIR /app
 ENV VEDIR /ve
+ENV LOG_FILTER_REGEX ^((?!\/healthcheck).)*$
 
 RUN sed -i 's/main$/main universe/g' /etc/apt/sources.list && \
     export DEBIAN_FRONTEND="noninteractive" && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,6 +42,7 @@ uwsgi \
     --socket=":9000" \
     --http-socket=":8080" \
     --touch-reload=/tmp/reload-app \
+    --log-filter="${LOG_FILTER_REGEX}" \
     --module "${FLASK_APP}"
 
 # --profiler


### PR DESCRIPTION
- Adds new env `LOG_FILTER_REGEX` that is passed to `--log-filter`. By default it filters `/healthcheck` endpoint from access logs.
- Bump gnitpick python to 3.10